### PR TITLE
Fix list item keys

### DIFF
--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/item/detail/ItemSourcesContent.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/item/detail/ItemSourcesContent.kt
@@ -86,7 +86,9 @@ fun ItemSourcesContent(
             if (combinationsExpanded) {
                 itemsIndexed(
                     items = sources.combinations,
-                    key = { _, combination -> "comb_${combination.itemA.id}" }
+                    key = { _, combination ->
+                        "comb_${combination.itemCreated.id}_${combination.itemA.id}_${combination.itemB.id}"
+                    }
                 ) { index, combination ->
                     val isLastItem = index == sources.combinations.lastIndex
 
@@ -166,7 +168,9 @@ fun ItemSourcesContent(
                         }
                         itemsIndexed(
                             items = items,
-                            key = { _, location -> "loc_${location.location.id}_${location.rank}_${location.area}_${location.type}" }
+                            key = { _, location ->
+                                "loc_${location.location.id}_${location.rank}_${location.type}_${location.area}"
+                            }
                         ) { index, location ->
                             val isLastItemInRank = index == items.lastIndex
                             val isLastItemInLocation = isLastItemInRank && (rank == lastRank)
@@ -224,7 +228,9 @@ fun ItemSourcesContent(
             if (monsterRewardsExpanded) {
                 itemsIndexed(
                     items = sources.monsterRewards,
-                    key = { _, monster -> "mr_${monster.monster.id}_${monster.rank}_${monster.condition}_${monster.percentage}" }
+                    key = { _, monster ->
+                        "mr_${monster.monster.id}_${monster.condition}_${monster.rank}_${monster.quantity}_${monster.percentage}"
+                    }
                 ) { index, monster ->
                     val isLastItem = index == sources.monsterRewards.lastIndex
 
@@ -296,7 +302,9 @@ fun ItemSourcesContent(
                     }
                     itemsIndexed(
                         items = quests,
-                        key = { _, quest -> "qr_${quest.quest.id}_${quest.condition}_${quest.percentage}" }
+                        key = { _, quest ->
+                            "qr_${quest.quest.id}_${quest.condition}_${quest.quantity}_${quest.percentage}"
+                        }
                     ) { index, quest ->
                         val isLastItemInHub = index == quests.lastIndex
                         val isGlobalLastItem = isLastItemInHub && (hub == lastHub)
@@ -352,7 +360,9 @@ fun ItemSourcesContent(
             if (veggieExpanded) {
                 itemsIndexed(
                     items = sources.veggieTrades,
-                    key = { _, trade -> "veg_${trade.location.id}_${trade.trade.itemTraded.id}" }
+                    key = { _, trade ->
+                        "veg_${trade.location.id}_${trade.trade.itemTraded.id}"
+                    }
                 ) { index, trade ->
                     val isLastItem = index == sources.veggieTrades.lastIndex
 

--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/item/detail/ItemUsagesContent.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/item/detail/ItemUsagesContent.kt
@@ -84,7 +84,9 @@ fun ItemUsagesContent(
             if (combinationsExpanded) {
                 itemsIndexed(
                     items = usages.combinations,
-                    key = { _, combination -> "comb_${combination.itemCreated.id}" }
+                    key = { _, combination ->
+                        "comb_${combination.itemCreated.id}_${combination.itemA.id}_${combination.itemB.id}"
+                    }
                 ) { index, combination ->
                     val isLastItem = index == usages.combinations.lastIndex
 
@@ -138,7 +140,9 @@ fun ItemUsagesContent(
             if (veggieExpanded) {
                 itemsIndexed(
                     items = usages.veggieTrades,
-                    key = { _, trade -> "veg_${trade.location.id}_${trade.trade.itemTraded.id}" }
+                    key = { _, trade ->
+                        "veg_${trade.location.id}_${trade.trade.itemTraded.id}"
+                    }
                 ) { index, trade ->
                     val isLastItem = index == usages.veggieTrades.lastIndex
 
@@ -192,7 +196,9 @@ fun ItemUsagesContent(
             if (armorExpanded) {
                 itemsIndexed(
                     items = usages.armors,
-                    key = { _, armor -> "armor_${armor.craftable.id}_${armor.quantity}" }
+                    key = { _, armor ->
+                        "armor_${armor.craftable.id}_${armor.quantity}"
+                    }
                 ) { index, armor ->
                     val isLastItem = index == usages.armors.lastIndex
 
@@ -246,7 +252,9 @@ fun ItemUsagesContent(
             if (decorationExpanded) {
                 itemsIndexed(
                     items = usages.decorations,
-                    key = { _, decoration -> "dec_${decoration.craftable.id}_${decoration.quantity}" }
+                    key = { _, decoration ->
+                        "dec_${decoration.craftable.id}_${decoration.quantity}"
+                    }
                 ) { index, decoration ->
                     val isLastItem = index == usages.decorations.lastIndex
 
@@ -300,7 +308,9 @@ fun ItemUsagesContent(
             if (weaponExpanded) {
                 itemsIndexed(
                     items = usages.weapons,
-                    key = { _, weapon -> "weapon_${weapon.craftable.id}_${weapon.quantity}" } // TODO: resolve conflicted keys, eq. `Hunter's Bow III`
+                    key = { _, weapon ->
+                        "weapon_${weapon.craftable.id}_${weapon.quantity}"
+                    }
                 ) { index, weapon ->
                     val isLastItem = index == usages.weapons.lastIndex
 

--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/itemcombination/list/ItemCombinationListScreen.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/itemcombination/list/ItemCombinationListScreen.kt
@@ -76,7 +76,9 @@ fun ItemCombinationListScreen(
         ) {
             itemsWithDivider(
                 items = uiState.itemCombinations,
-                key = { combination -> "${combination.itemCreated.id}_${combination.itemA.id}_${combination.itemB.id}" }
+                key = { combination ->
+                    "${combination.itemCreated.id}_${combination.itemA.id}_${combination.itemB.id}"
+                }
             ) { combination ->
                 ItemCombinationListItem(
                     combination = combination,

--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/location/detail/LocationDetailRankContent.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/location/detail/LocationDetailRankContent.kt
@@ -101,7 +101,9 @@ fun LocationDetailRankContent(
                     }
                     itemsIndexed(
                         items = items,
-                        key = { _, point -> "point_${point.rank}_${point.area}_${point.type}_${point.item.id}" }
+                        key = { _, point ->
+                            "point_${point.rank}_${point.area}_${point.type}_${point.item.id}"
+                        }
                     ) { index, point ->
                         val isLastType = type == itemsPerType.keys.last()
                         val isLastItemInType = index == items.lastIndex

--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/monster/detail/MonsterDetailRewardContent.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/monster/detail/MonsterDetailRewardContent.kt
@@ -80,7 +80,9 @@ fun MonsterDetailRewardContent(
             if (isConditionExpanded) {
                 itemsIndexed(
                     items = rewards,
-                    key = { _, reward -> "reward_${reward.item.id}_${reward.condition}_${reward.percentage}" }
+                    key = { _, reward ->
+                        "${reward.item.id}_${reward.condition}_${reward.rank}_${reward.quantity}_${reward.percentage}"
+                    }
                 ) { index, reward ->
                     val isLastItemInCondition = index == rewards.lastIndex
 

--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/quest/detail/QuestDetailRewardContent.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/quest/detail/QuestDetailRewardContent.kt
@@ -80,7 +80,9 @@ fun QuestDetailRewardContent(
             if (isConditionExpanded) {
                 itemsIndexed(
                     items = rewards,
-                    key = { _, reward -> "reward_${reward.item.id}_${reward.condition}_${reward.quantity}_${reward.percentage}" }
+                    key = { _, reward ->
+                        "${reward.item.id}_${reward.condition}_${reward.quantity}_${reward.percentage}"
+                    }
                 ) { index, reward ->
                     val isLastItemInCondition = index == rewards.lastIndex
 

--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/veggie/detail/VeggieDetailScreen.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/veggie/detail/VeggieDetailScreen.kt
@@ -78,7 +78,9 @@ fun VeggieDetailScreen(
             ) {
                 itemsWithDivider(
                     items = trades,
-                    key = { trade -> "${trade.itemTraded.id}_${trade.itemCommon.id}_${trade.itemRare.id}" }
+                    key = { trade ->
+                        "${trade.itemTraded.id}_${trade.itemCommon.id}_${trade.itemRare.id}"
+                    }
                 ) { trade ->
                     VeggieTradeListItem(
                         veggieTrade = trade,

--- a/core/data/src/main/java/com/gaugustini/mhfudatabase/data/database/dao/ItemDao.kt
+++ b/core/data/src/main/java/com/gaugustini/mhfudatabase/data/database/dao/ItemDao.kt
@@ -94,7 +94,7 @@ interface ItemDao {
 
     @Query(
         """
-        SELECT 
+        SELECT DISTINCT
             li.location_id AS li_location_id, li.item_id AS li_item_id, li.rank AS li_rank, li.gather_type AS li_gather_type, li.area AS li_area,
             location.*,
             location_text.*
@@ -187,7 +187,7 @@ interface ItemDao {
 
     @Query(
         """
-        SELECT 
+        SELECT DISTINCT
             armor.*,
             armor_text.*,
             armor_recipe.quantity
@@ -205,7 +205,7 @@ interface ItemDao {
 
     @Query(
         """
-        SELECT
+        SELECT DISTINCT
             decoration.id AS dec_id, decoration.shop_order AS dec_shop_order, decoration.required_slots AS dec_required_slots,
             item.*,
             item_text.*,
@@ -244,7 +244,7 @@ interface ItemDao {
 
     @Query(
         """
-        SELECT
+        SELECT DISTINCT
             weapon.*,
             weapon_text.*,
             weapon_recipe.quantity

--- a/core/data/src/main/java/com/gaugustini/mhfudatabase/data/database/dao/LocationDao.kt
+++ b/core/data/src/main/java/com/gaugustini/mhfudatabase/data/database/dao/LocationDao.kt
@@ -41,7 +41,7 @@ interface LocationDao {
 
     @Query(
         """
-        SELECT 
+        SELECT DISTINCT
             li.location_id AS li_location_id, li.item_id AS li_item_id, li.rank AS li_rank, li.gather_type AS li_gather_type, li.area AS li_area,
             item.*,
             item_text.*


### PR DESCRIPTION
- Add `DISTINCT` to SQL queries in `ItemDao` and `LocationDao` to prevent duplicate result sets.
- Update `key` logic for `LazyColumn` items across various screens to ensure unique IDs.