### PR TITLE
Fix localization in filters

### DIFF
--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/armor/list/ArmorSetListScreen.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/armor/list/ArmorSetListScreen.kt
@@ -133,19 +133,24 @@ fun ArmorSetListFilter(
     var typeMenuExpanded by remember { mutableStateOf(false) }
 
     Row(
+        horizontalArrangement = Arrangement.spacedBy(Dimension.Spacing.medium),
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = Dimension.Padding.medium),
-        horizontalArrangement = Arrangement.spacedBy(Dimension.Spacing.medium)
     ) {
         Box {
             FilterChip(
-                selected = filter.hunterType != null,
+                selected = filter.hunterType != null && filter.hunterType != HunterType.BOTH,
                 onClick = { typeMenuExpanded = true },
                 label = {
                     Text(
-                        filter.hunterType?.name?.lowercase()?.replaceFirstChar { it.uppercase() }
-                            ?: "All Types"
+                        text = stringResource(
+                            when (filter.hunterType) {
+                                HunterType.BLADE -> R.string.armor_set_filter_hunter_blade
+                                HunterType.GUNNER -> R.string.armor_set_filter_hunter_gunner
+                                else -> R.string.armor_set_filter_hunter_all
+                            }
+                        )
                     )
                 },
                 trailingIcon = {
@@ -161,22 +166,23 @@ fun ArmorSetListFilter(
                 expanded = typeMenuExpanded,
                 onDismissRequest = { typeMenuExpanded = false }
             ) {
-                DropdownMenuItem(
-                    text = { Text("All Types") },
-                    onClick = {
-                        onFilterChange(filter.copy(hunterType = null))
-                        typeMenuExpanded = false
-                    }
-                )
                 HunterType.entries.forEach { type ->
                     DropdownMenuItem(
                         text = {
                             Text(
-                                type.name.lowercase().replaceFirstChar { it.uppercase() }
+                                text = stringResource(
+                                    when (type) {
+                                        HunterType.BOTH -> R.string.armor_set_filter_hunter_all
+                                        HunterType.BLADE -> R.string.armor_set_filter_hunter_blade
+                                        HunterType.GUNNER -> R.string.armor_set_filter_hunter_gunner
+                                    }
+                                )
                             )
                         },
                         onClick = {
-                            onFilterChange(filter.copy(hunterType = type))
+                            onFilterChange(
+                                filter.copy(hunterType = if (type == HunterType.BOTH) null else type)
+                            )
                             typeMenuExpanded = false
                         }
                     )

--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/location/detail/LocationDetailRankContent.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/location/detail/LocationDetailRankContent.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.gaugustini.mhfudatabase.R
 import com.gaugustini.mhfudatabase.domain.enums.GatherType
+import com.gaugustini.mhfudatabase.domain.enums.Rank
 import com.gaugustini.mhfudatabase.domain.model.GatheringPoint
 import com.gaugustini.mhfudatabase.ui.components.AppHDivider
 import com.gaugustini.mhfudatabase.ui.components.SectionHeader
@@ -38,10 +39,11 @@ import com.gaugustini.mhfudatabase.util.preview.PreviewLocationData
 fun LocationDetailRankContent(
     gatheringPoints: List<GatheringPoint>,
     modifier: Modifier = Modifier,
+    rank: Rank? = null,
     onItemClick: (itemId: Int) -> Unit = {},
 ) {
     val itemsPerArea = gatheringPoints.groupBy { it.area }
-    var expandedAreas by rememberSaveable(itemsPerArea.keys) {
+    var expandedAreas by rememberSaveable(rank) {
         mutableStateOf(itemsPerArea.keys.toSet())
     }
 

--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/location/detail/LocationDetailScreen.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/location/detail/LocationDetailScreen.kt
@@ -1,18 +1,27 @@
 package com.gaugustini.mhfudatabase.ui.features.location.detail
 
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -78,6 +87,7 @@ fun LocationDetailScreen(
     ) { innerPadding ->
         if (uiState.location != null) {
             LocationDetailRankContent(
+                rank = uiState.rank,
                 gatheringPoints = uiState.gatheringPoints,
                 onItemClick = onItemClick,
                 modifier = Modifier.padding(innerPadding),
@@ -95,24 +105,68 @@ fun LocationDetailRankFilter(
 ) {
     if (availableRanks.isEmpty() || selectedRank == null) return
 
+    var typeMenuExpanded by remember { mutableStateOf(false) }
+
     Row(
         horizontalArrangement = Arrangement.spacedBy(Dimension.Spacing.medium),
         modifier = modifier
             .fillMaxWidth()
-            .horizontalScroll(rememberScrollState())
             .padding(horizontal = Dimension.Padding.medium),
     ) {
-        availableRanks.forEach { rank ->
+        Box {
             FilterChip(
-                selected = rank == selectedRank,
-                onClick = { onChangeRank(rank) },
+                selected = true,
+                onClick = { typeMenuExpanded = true },
                 label = {
                     Text(
-                        rank.name.lowercase()
-                            .replaceFirstChar { it.uppercase() } // TODO: Change to string resources
+                        text = stringResource(
+                            when (selectedRank) {
+                                Rank.UNRANKED -> R.string.location_filter_rank_unranked
+                                Rank.LOW -> R.string.location_filter_rank_low
+                                Rank.HIGH -> R.string.location_filter_rank_high
+                                Rank.G -> R.string.location_filter_rank_g
+                                Rank.TREASURE -> R.string.location_filter_rank_treasure
+                                Rank.TRAINING -> R.string.location_filter_rank_training
+                            }
+                        )
+                    )
+                },
+                trailingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.ArrowDropDown,
+                        contentDescription = null,
+                        modifier = Modifier.size(FilterChipDefaults.IconSize)
+                    )
+                },
+            )
+
+            DropdownMenu(
+                expanded = typeMenuExpanded,
+                onDismissRequest = { typeMenuExpanded = false }
+            ) {
+                availableRanks.forEach { rank ->
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                text = stringResource(
+                                    when (rank) {
+                                        Rank.UNRANKED -> R.string.location_filter_rank_unranked
+                                        Rank.LOW -> R.string.location_filter_rank_low
+                                        Rank.HIGH -> R.string.location_filter_rank_high
+                                        Rank.G -> R.string.location_filter_rank_g
+                                        Rank.TREASURE -> R.string.location_filter_rank_treasure
+                                        Rank.TRAINING -> R.string.location_filter_rank_training
+                                    }
+                                )
+                            )
+                        },
+                        onClick = {
+                            onChangeRank(rank)
+                            typeMenuExpanded = false
+                        }
                     )
                 }
-            )
+            }
         }
     }
 }

--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/monster/detail/MonsterDetailRewardContent.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/monster/detail/MonsterDetailRewardContent.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import com.gaugustini.mhfudatabase.domain.enums.Rank
 import com.gaugustini.mhfudatabase.domain.model.MonsterReward
 import com.gaugustini.mhfudatabase.ui.components.AppHDivider
 import com.gaugustini.mhfudatabase.ui.components.SectionHeader
@@ -36,6 +37,7 @@ import com.gaugustini.mhfudatabase.util.preview.PreviewMonsterData
 fun MonsterDetailRewardContent(
     rewards: List<MonsterReward>,
     modifier: Modifier = Modifier,
+    rank: Rank? = null,
     onItemClick: (itemId: Int) -> Unit = {},
     onChangePage: (MonsterDetailPage) -> Unit = {},
 ) {
@@ -44,7 +46,7 @@ fun MonsterDetailRewardContent(
     }
 
     val rewardsPerCondition = rewards.groupBy { it.condition }
-    var expandedConditions by rememberSaveable(rewardsPerCondition.keys) {
+    var expandedConditions by rememberSaveable(rank) {
         mutableStateOf(rewardsPerCondition.keys.toSet())
     }
 

--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/monster/detail/MonsterDetailScreen.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/monster/detail/MonsterDetailScreen.kt
@@ -1,18 +1,27 @@
 package com.gaugustini.mhfudatabase.ui.features.monster.detail
 
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -116,6 +125,7 @@ fun MonsterDetailScreen(
 
                 MonsterDetailPage.REWARD -> {
                     MonsterDetailRewardContent(
+                        rank = uiState.rewardRank,
                         rewards = uiState.rewards,
                         onItemClick = onItemClick,
                         onChangePage = onChangePage,
@@ -145,24 +155,68 @@ fun MonsterDetailRankFilter(
 ) {
     if (availableRanks.isEmpty() || selectedRank == null) return
 
+    var typeMenuExpanded by remember { mutableStateOf(false) }
+
     Row(
         horizontalArrangement = Arrangement.spacedBy(Dimension.Spacing.medium),
         modifier = modifier
             .fillMaxWidth()
-            .horizontalScroll(rememberScrollState())
             .padding(horizontal = Dimension.Padding.medium),
     ) {
-        availableRanks.forEach { rank ->
+        Box {
             FilterChip(
-                selected = rank == selectedRank,
-                onClick = { onChangeRank(rank) },
+                selected = true,
+                onClick = { typeMenuExpanded = true },
                 label = {
                     Text(
-                        rank.name.lowercase()
-                            .replaceFirstChar { it.uppercase() } // TODO: Change to string resources
+                        text = stringResource(
+                            when (selectedRank) {
+                                Rank.UNRANKED -> R.string.monster_reward_filter_rank_unranked
+                                Rank.LOW -> R.string.monster_reward_filter_rank_low
+                                Rank.HIGH -> R.string.monster_reward_filter_rank_high
+                                Rank.G -> R.string.monster_reward_filter_rank_g
+                                Rank.TREASURE -> R.string.monster_reward_filter_rank_treasure
+                                Rank.TRAINING -> R.string.monster_reward_filter_rank_training
+                            }
+                        )
+                    )
+                },
+                trailingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.ArrowDropDown,
+                        contentDescription = null,
+                        modifier = Modifier.size(FilterChipDefaults.IconSize)
+                    )
+                },
+            )
+
+            DropdownMenu(
+                expanded = typeMenuExpanded,
+                onDismissRequest = { typeMenuExpanded = false }
+            ) {
+                availableRanks.forEach { rank ->
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                text = stringResource(
+                                    when (rank) {
+                                        Rank.UNRANKED -> R.string.monster_reward_filter_rank_unranked
+                                        Rank.LOW -> R.string.monster_reward_filter_rank_low
+                                        Rank.HIGH -> R.string.monster_reward_filter_rank_high
+                                        Rank.G -> R.string.monster_reward_filter_rank_g
+                                        Rank.TREASURE -> R.string.monster_reward_filter_rank_treasure
+                                        Rank.TRAINING -> R.string.monster_reward_filter_rank_training
+                                    }
+                                )
+                            )
+                        },
+                        onClick = {
+                            onChangeRank(rank)
+                            typeMenuExpanded = false
+                        }
                     )
                 }
-            )
+            }
         }
     }
 }

--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/monster/list/MonsterListScreen.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/monster/list/MonsterListScreen.kt
@@ -125,10 +125,10 @@ fun MonsterListFilter(
     var typeMenuExpanded by remember { mutableStateOf(false) }
 
     Row(
+        horizontalArrangement = Arrangement.spacedBy(Dimension.Spacing.medium),
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = Dimension.Padding.medium),
-        horizontalArrangement = Arrangement.spacedBy(Dimension.Spacing.medium)
     ) {
         Box {
             FilterChip(
@@ -136,9 +136,13 @@ fun MonsterListFilter(
                 onClick = { typeMenuExpanded = true },
                 label = {
                     Text(
-                        filter.type?.name?.lowercase()
-                            ?.replaceFirstChar { it.uppercase() } // TODO: Change to string resources
-                            ?: "All Types"
+                        text = stringResource(
+                            when (filter.type) {
+                                MonsterType.SMALL -> R.string.monster_filter_size_small
+                                MonsterType.LARGE -> R.string.monster_filter_size_large
+                                else -> R.string.monster_filter_size_all
+                            }
+                        )
                     )
                 },
                 trailingIcon = {
@@ -155,7 +159,11 @@ fun MonsterListFilter(
                 onDismissRequest = { typeMenuExpanded = false }
             ) {
                 DropdownMenuItem(
-                    text = { Text("All Types") },
+                    text = {
+                        Text(
+                            text = stringResource(R.string.monster_filter_size_all),
+                        )
+                    },
                     onClick = {
                         onFilterChange(filter.copy(type = null))
                         typeMenuExpanded = false
@@ -165,7 +173,12 @@ fun MonsterListFilter(
                     DropdownMenuItem(
                         text = {
                             Text(
-                                type.name.lowercase().replaceFirstChar { it.uppercase() }
+                                text = stringResource(
+                                    when (type) {
+                                        MonsterType.SMALL -> R.string.monster_filter_size_small
+                                        MonsterType.LARGE -> R.string.monster_filter_size_large
+                                    }
+                                )
                             )
                         },
                         onClick = {

--- a/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/quest/list/QuestListScreen.kt
+++ b/app/src/main/java/com/gaugustini/mhfudatabase/ui/features/quest/list/QuestListScreen.kt
@@ -129,10 +129,10 @@ fun QuestListFilter(
     var typeMenuExpanded by remember { mutableStateOf(false) }
 
     Row(
+        horizontalArrangement = Arrangement.spacedBy(Dimension.Spacing.medium),
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = Dimension.Padding.medium),
-        horizontalArrangement = Arrangement.spacedBy(Dimension.Spacing.medium)
     ) {
         Box {
             FilterChip(
@@ -140,9 +140,14 @@ fun QuestListFilter(
                 onClick = { typeMenuExpanded = true },
                 label = {
                     Text(
-                        filter.hub?.name?.lowercase()
-                            ?.replaceFirstChar { it.uppercase() } // TODO: Change to string resources
-                            ?: "All Types"
+                        text = stringResource(
+                            when (filter.hub) {
+                                HubType.VILLAGE -> R.string.quest_filter_hub_village
+                                HubType.GUILD -> R.string.quest_filter_hub_guild
+                                HubType.TRAINING -> R.string.quest_filter_hub_training
+                                else -> R.string.quest_filter_hub_all
+                            }
+                        )
                     )
                 },
                 trailingIcon = {
@@ -159,7 +164,11 @@ fun QuestListFilter(
                 onDismissRequest = { typeMenuExpanded = false }
             ) {
                 DropdownMenuItem(
-                    text = { Text("All Types") },
+                    text = {
+                        Text(
+                            text = stringResource(R.string.quest_filter_hub_all),
+                        )
+                    },
                     onClick = {
                         onFilterChange(filter.copy(hub = null))
                         typeMenuExpanded = false
@@ -169,7 +178,13 @@ fun QuestListFilter(
                     DropdownMenuItem(
                         text = {
                             Text(
-                                type.name.lowercase().replaceFirstChar { it.uppercase() }
+                                text = stringResource(
+                                    when (type) {
+                                        HubType.VILLAGE -> R.string.quest_filter_hub_village
+                                        HubType.GUILD -> R.string.quest_filter_hub_guild
+                                        HubType.TRAINING -> R.string.quest_filter_hub_training
+                                    }
+                                )
                             )
                         },
                         onClick = {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -153,6 +153,9 @@
     <string name="search_weapon">Arma</string>
 
     <!-- Armor -->
+    <string name="armor_set_filter_hunter_all">Todos</string>
+    <string name="armor_set_filter_hunter_blade">Maestro Espada</string>
+    <string name="armor_set_filter_hunter_gunner">Artillero</string>
     <string name="armor_set_details">Conjunto de armadura</string>
     <string name="armor_rarity">Rareza %1$d</string>
     <string name="armor_defense">Defensa (Max.)</string>
@@ -184,8 +187,8 @@
     <string name="item_location">Localización</string>
     <string name="item_monster">Monstruo</string>
     <string name="item_rank_unranked">Gremio 1★~2★</string>
-    <string name="item_rank_low">Rango Bajo/Anciana</string>
-    <string name="item_rank_high">Rango Alto/Nekoht</string>
+    <string name="item_rank_low">Rango Bajo</string>
+    <string name="item_rank_high">Rango Alto</string>
     <string name="item_rank_g">Rango G</string>
     <string name="item_rank_treasure">Tesoro</string>
     <string name="item_rank_training">Entrenamiento</string>
@@ -228,6 +231,12 @@
     <string name="combination_alchemy">Alquimia</string>
 
     <!-- Location -->
+    <string name="location_filter_rank_unranked">Principiante</string>
+    <string name="location_filter_rank_low">Rango Bajo</string>
+    <string name="location_filter_rank_high">Rango Alto</string>
+    <string name="location_filter_rank_g">Rango G</string>
+    <string name="location_filter_rank_treasure">Tesoros</string>
+    <string name="location_filter_rank_training">Entrenamiento</string>
     <string name="location_secret_area">Área Secreta</string>
     <string name="location_base_camp">Campamento Base</string>
     <string name="location_area">Área %1$d</string>
@@ -237,6 +246,15 @@
     <string name="location_gather_fish">Pesca</string>
 
     <!-- Monster -->
+    <string name="monster_filter_size_all">Todos</string>
+    <string name="monster_filter_size_small">Pequeño</string>
+    <string name="monster_filter_size_large">Grande</string>
+    <string name="monster_reward_filter_rank_unranked">Gremio 1★~2★</string>
+    <string name="monster_reward_filter_rank_low">Rango Bajo</string>
+    <string name="monster_reward_filter_rank_high">Rango Alto</string>
+    <string name="monster_reward_filter_rank_g">Rango G</string>
+    <string name="monster_reward_filter_rank_treasure">Tesoros</string>
+    <string name="monster_reward_filter_rank_training">Entrenamiento</string>
     <string name="monster_damage_stats">Info. de Daño</string>
     <string name="monster_reward">Recompensas (Brillos/Captura/Partes Rompibles)</string>
     <string name="monster_quest">Misiones</string>
@@ -291,6 +309,10 @@
     <string name="monster_quest_group_group_challenge">Desafio</string>
 
     <!-- Quest -->
+    <string name="quest_filter_hub_all">Todos</string>
+    <string name="quest_filter_hub_village">Aldea</string>
+    <string name="quest_filter_hub_guild">Gremio</string>
+    <string name="quest_filter_hub_training">Entrenamiento</string>
     <string name="quest_type_key">Clave</string>
     <string name="quest_type_urgent">Urgente</string>
     <string name="quest_village_stars">Aldea %1$d ★</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,9 @@
     <string name="search_weapon">Weapon</string>
 
     <!-- Armor -->
+    <string name="armor_set_filter_hunter_all">All</string>
+    <string name="armor_set_filter_hunter_blade">Blademaster</string>
+    <string name="armor_set_filter_hunter_gunner">Gunner</string>
     <string name="armor_set_details">Armor Set</string>
     <string name="armor_rarity">Rarity %1$d</string>
     <string name="armor_defense">Defense (Max.)</string>
@@ -184,8 +187,8 @@
     <string name="item_location">Location</string>
     <string name="item_monster">Monster</string>
     <string name="item_rank_unranked">Guild 1★~2★</string>
-    <string name="item_rank_low">Low Rank/Elder</string>
-    <string name="item_rank_high">High Rank/Nekoht</string>
+    <string name="item_rank_low">Low Rank</string>
+    <string name="item_rank_high">High Rank</string>
     <string name="item_rank_g">G Rank</string>
     <string name="item_rank_treasure">Treasure</string>
     <string name="item_rank_training">Training</string>
@@ -228,6 +231,12 @@
     <string name="combination_alchemy">Alchemy</string>
 
     <!-- Location -->
+    <string name="location_filter_rank_unranked">Beginner</string>
+    <string name="location_filter_rank_low">Low Rank</string>
+    <string name="location_filter_rank_high">High Rank</string>
+    <string name="location_filter_rank_g">G Rank</string>
+    <string name="location_filter_rank_treasure">Treasure</string>
+    <string name="location_filter_rank_training">Training</string>
     <string name="location_secret_area">Secret Area</string>
     <string name="location_base_camp">Base Camp</string>
     <string name="location_area">Area %1$d</string>
@@ -237,6 +246,15 @@
     <string name="location_gather_fish">Fishing</string>
 
     <!-- Monster -->
+    <string name="monster_filter_size_all">All</string>
+    <string name="monster_filter_size_small">Small</string>
+    <string name="monster_filter_size_large">Large</string>
+    <string name="monster_reward_filter_rank_unranked">Guild 1★~2★</string>
+    <string name="monster_reward_filter_rank_low">Low Rank</string>
+    <string name="monster_reward_filter_rank_high">High Rank</string>
+    <string name="monster_reward_filter_rank_g">G Rank</string>
+    <string name="monster_reward_filter_rank_treasure">Treasure</string>
+    <string name="monster_reward_filter_rank_training">Training</string>
     <string name="monster_damage_stats">Damage Stats</string>
     <string name="monster_reward">Rewards (Shiny/Capture/Breakable Parts)</string>
     <string name="monster_quest">Quests</string>
@@ -291,6 +309,10 @@
     <string name="monster_quest_group_group_challenge">Challenge</string>
 
     <!-- Quest -->
+    <string name="quest_filter_hub_all">All</string>
+    <string name="quest_filter_hub_village">Village</string>
+    <string name="quest_filter_hub_guild">Guild</string>
+    <string name="quest_filter_hub_training">Training</string>
     <string name="quest_type_key">Key</string>
     <string name="quest_type_urgent">Urgent</string>
     <string name="quest_village_stars">Village %1$d ★</string>

--- a/core/data/src/main/java/com/gaugustini/mhfudatabase/data/database/dao/ArmorSetDao.kt
+++ b/core/data/src/main/java/com/gaugustini/mhfudatabase/data/database/dao/ArmorSetDao.kt
@@ -58,7 +58,7 @@ interface ArmorSetDao {
             (:name IS NULL OR armor_set_text.name LIKE '%' || :name || '%')
             AND (:hasRarityFilter = 0 OR armor_set.rarity IN (:rarity))
             AND (:rank IS NULL OR armor_set.rank = :rank)
-            AND (:hunterType IS NULL OR armor_set.hunter_type = :hunterType)
+            AND (:hasHunterTypeFilter = 0 OR armor_set.hunter_type IN (:hunterType))
             AND (:gender IS NULL OR armor_set.gender = :gender)
             AND (:hasSkillFilter = 0 OR EXISTS (
                 SELECT 1 FROM armor_skill
@@ -75,7 +75,8 @@ interface ArmorSetDao {
         rarity: List<Int>?,
         hasRarityFilter: Boolean,
         rank: String?,
-        hunterType: String?,
+        hunterType: List<String>?,
+        hasHunterTypeFilter: Boolean,
         gender: String?,
         skills: List<Int>?,
         hasSkillFilter: Boolean,

--- a/core/data/src/main/java/com/gaugustini/mhfudatabase/data/repository/ArmorRepository.kt
+++ b/core/data/src/main/java/com/gaugustini/mhfudatabase/data/repository/ArmorRepository.kt
@@ -4,6 +4,7 @@ import com.gaugustini.mhfudatabase.data.database.dao.ArmorDao
 import com.gaugustini.mhfudatabase.data.database.dao.ArmorSetDao
 import com.gaugustini.mhfudatabase.data.mapper.ArmorMapper
 import com.gaugustini.mhfudatabase.data.mapper.ArmorSetMapper
+import com.gaugustini.mhfudatabase.domain.enums.HunterType
 import com.gaugustini.mhfudatabase.domain.filter.ArmorFilter
 import com.gaugustini.mhfudatabase.domain.filter.ArmorSetFilter
 import com.gaugustini.mhfudatabase.domain.model.Armor
@@ -94,7 +95,8 @@ class ArmorRepository @Inject constructor(
             rarity = filter.rarity,
             hasRarityFilter = !filter.rarity.isNullOrEmpty(),
             rank = filter.rank?.name,
-            hunterType = filter.hunterType?.name,
+            hunterType = filter.hunterType?.let { listOf(it.name, HunterType.BOTH.name) },
+            hasHunterTypeFilter = filter.hunterType != null,
             gender = filter.gender?.name,
             skills = filter.skills?.map { it.id },
             hasSkillFilter = !filter.skills.isNullOrEmpty(),


### PR DESCRIPTION
- Replace hardcoded strings with string resources.
- Add `DropdownMenu` for rank selection in `MonsterDetailScreen` and `LocationDetailScreen` to replace horizontal scrolling chips.
- Update `ArmorSetDao` and `ArmorRepository` to correctly filter hunter types, ensuring "Both" options are handled properly in queries.